### PR TITLE
FOGL-1804: modbus c Debian packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# vi
+*.swp
+
+# MacOS Finder
+.DS_Store
+._*
+
+# build
+build
+
+# packaging
+packages/build

--- a/README.rst
+++ b/README.rst
@@ -72,3 +72,54 @@ Examples:
   $ cmake -DFOGLAMP_INSTALL=/home/source/develop/FogLAMP
 
   $ cmake -DFOGLAMP_INSTALL=/usr/local/foglamp
+
+******************************
+Packaging for 'modbusc' south
+******************************
+
+This repo contains the scripts used to create a foglamp-south-modbusc Debian package.
+
+The make_deb script
+===================
+
+Run the make_deb command after compiling the plugin:
+
+.. code-block:: console
+
+  $ ./make_deb help
+  make_deb {x86|arm} [help|clean|cleanall]
+  This script is used to create the Debian package of FoglAMP C++ 'modbusc' south plugin
+  Arguments:
+   help     - Display this help text
+   x86      - Build an x86_64 package
+   arm      - Build an armv7l package
+   clean    - Remove all the old versions saved in format .XXXX
+   cleanall - Remove all the versions, including the last one
+  $
+
+Building a Package
+==================
+
+Finally, run the ``make_deb`` command:
+
+.. code-block:: console
+
+   $ ./make_deb
+   The package root directory is   : /home/ubuntu/source/foglamp-south-modbus-c
+   The FogLAMP required version    : >=1.4
+   The package will be built in    : /home/ubuntu/source/foglamp-south-modbus-c/packages/build
+   The architecture is set as      : x86_64
+   The package name is             : foglamp-south-modbusc-1.0.0-x86_64
+
+   Populating the package and updating version file...Done.
+   Building the new package...
+   dpkg-deb: building package 'foglamp-south-modbusc' in 'foglamp-south-modbusc-1.0.0-x86_64.deb'.
+   Building Complete.
+   $
+
+Cleaning the Package Folder
+===========================
+
+Use the ``clean`` option to remove all the old packages and the files used to make the package.
+
+Use the ``cleanall`` option to remove all the packages and the files used to make the package.

--- a/foglamp.version
+++ b/foglamp.version
@@ -1,0 +1,1 @@
+foglamp_version>=1.4

--- a/make_deb
+++ b/make_deb
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+##--------------------------------------------------------------------
+## Copyright (c) 2018 Dianomic Systems
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+##
+## Author: Massimiliano Pinto
+##
+
+set -e
+
+architecture="none"
+plugin_type="south"
+plugin_name="modbusc"
+plugin_install_dirname="ModbusC"
+usage="$(basename "$0") {x86|arm} [help|clean|cleanall]
+This script is used to create the Debian package of FoglAMP C++ '${plugin_name}' ${plugin_type} plugin
+Arguments:
+ help     - Display this help text
+ x86      - Build an x86_64 package
+ arm      - Build an armv7l package
+ clean    - Remove all the old versions saved in format .XXXX
+ cleanall - Remove all the versions, including the last one"
+
+GIT_ROOT=`pwd`    # The script must be executed from the root git directory
+if [ $# -gt 0 ]; then
+    for i in "$@"
+    do
+        case "$i" in
+          x86)
+              architecture="x86_64"
+              shift
+              ;;
+          arm)
+              architecture="armhf"
+              shift
+              ;;
+          clean)
+              echo -n "Cleaning the build folder from older versions..."
+              find "${GIT_ROOT}/packages/build" -maxdepth 1 | grep '.*\.[0-9][0-9][0-9][0-9]' | xargs rm -rf
+              echo "Done."
+              shift
+              ;;
+          cleanall)
+              if [ -d "${GIT_ROOT}/packages/build" ]; then
+                  echo -n "Cleaning the build folder..."
+                  rm -rf ${GIT_ROOT}/packages/build/*
+                  echo "Done."
+              else
+                  echo "No build folder, skipping cleanall"
+              fi
+              shift
+              ;;
+          help)
+              echo "${usage}"
+              exit 0
+              ;;
+          *)
+              echo "Unrecognized option: $i"
+             exit 1
+            ;;
+      esac
+    done
+else
+  echo "See help and select the architecture to use, *x86* or *arm*"
+  exit 1
+fi
+
+# If the architecture has not been defined, then the script is complete
+if [[ "$architecture" == "none" ]]; then
+  exit 0
+fi
+
+# Get plugin version from plugin.cpp, grep comment: // Version
+plugin_version=`cat ${GIT_ROOT}/plugin.cpp | grep 'Version' | head -1 | tr -d ' ' | awk -F',' '{print $1}' | sed -e 's/\"//g' | sed -e 's/[[:space:]]\+//g'`
+# Get FogLAMP version dependency from foglamp_version file
+foglamp_version=`cat ${GIT_ROOT}/foglamp.version | tr -d ' ' | grep 'foglamp_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
+BUILD_ROOT="${GIT_ROOT}/packages/build"
+
+# Final package name
+package_name="foglamp-${plugin_type}-${plugin_name}-${plugin_version}-${architecture}"
+
+# Print the summary of findings
+echo "The package root directory is   : ${GIT_ROOT}"
+echo "The FogLAMP required version    : ${foglamp_version}"
+echo "The package will be built in    : ${BUILD_ROOT}"
+echo "The architecture is set as      : ${architecture}"
+echo "The package name is             : ${package_name}"
+echo
+
+# Create the package directory. If a directory with the same name exists,
+# it is copied with a version number.
+
+# First, create the BUILD_ROOT folder, if necessary
+if [ ! -L "${BUILD_ROOT}" -a ! -d "${BUILD_ROOT}" ]; then
+    mkdir -p "${BUILD_ROOT}"
+fi
+
+# Checl plugin has been built
+if [ ! -d "${GIT_ROOT}/build" ]; then
+    echo "Error: ./build directory not found."
+    echo "Build plugin ${plugin_name} first."
+    echo "mkdir ./build; cd ./build; cmake ..; make; cd .."
+    exit 1
+fi
+
+cd "${BUILD_ROOT}"
+existing_pkgs=`find . -maxdepth 1 -name "${package_name}.????" | wc -l`
+existing_pkgs=$((existing_pkgs+1))
+new_stored_pkg=$(printf "${package_name}.%04d" "${existing_pkgs}")
+if [ -d "${package_name}" ]; then
+    echo "Saving the old working environment as ${new_stored_pkg}"
+    mv "${package_name}" "${new_stored_pkg}"
+fi
+mkdir "${package_name}"
+
+# Populate the package directory with Debian files
+# First with files common to all pla
+echo -n "Populating the package and updating version file..."
+cd "${package_name}"
+cp -R ${GIT_ROOT}/packages/Debian/common/* .
+cp -R ${GIT_ROOT}/packages/Debian/${architecture}/* .
+sed -i "s/Version: 1.0.0/Version: ${plugin_version}/g" DEBIAN/control
+sed -i "s/Depends: foglamp/Depends: foglamp (${foglamp_version})/g" DEBIAN/control
+
+mkdir -p usr/local/foglamp
+cd usr/local/foglamp
+mkdir -p "plugins/${plugin_type}/${plugin_install_dirname}"
+cp -R --preserve=links ${GIT_ROOT}/build/lib*.so* "plugins/${plugin_type}/${plugin_install_dirname}"
+echo "Done."
+
+# Build the package
+cd "${BUILD_ROOT}"
+
+# Save the old versions
+existing_pkgs=`find . -maxdepth 1 -name "${package_name}.deb.????" | wc -l`
+existing_pkgs=$((existing_pkgs+1))
+new_stored_pkg=$(printf "${package_name}.deb.%04d" "${existing_pkgs}")
+
+if [ -e "${package_name}.deb" ]; then
+    echo "Saving the old package as ${new_stored_pkg}"
+    mv "${package_name}.deb" "${new_stored_pkg}"
+fi
+
+echo "Building the new package..."
+dpkg-deb --build ${package_name}
+echo "Building Complete."
+
+exit 0

--- a/packages/Debian/armhf/DEBIAN/control
+++ b/packages/Debian/armhf/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: foglamp-south-modbusc
+Version: 1.0.0
+Section: devel
+Priority: optional
+Architecture: armhf
+Depends: foglamp
+Conflicts:
+Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
+Homepage: http://www.dianomic.com
+Description: FogLAMP C++ Modbus south plugin

--- a/packages/Debian/common/DEBIAN/postint
+++ b/packages/Debian/common/DEBIAN/postint
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+##--------------------------------------------------------------------
+## Copyright (c) 2018 Dianomic Systems
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## @postinst DEBIAN/postinst
+## This script is used to execute post installation tasks.
+##
+## Author: Massimiliano Pinto
+##
+##--------------------------------------------------------------------
+
+set -e
+
+set_files_ownership () {
+    chown -R root:root /usr/local/foglamp/plugins/south/ModbusC
+}
+
+set_files_ownership

--- a/packages/Debian/common/DEBIAN/preinst
+++ b/packages/Debian/common/DEBIAN/preinst
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+##--------------------------------------------------------------------
+## Copyright (c) 2018 Dianomic Systems
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## @preinst DEBIAN/preinst
+## This script is used to execute pre installation tasks.
+##
+## Author: Massimiliano Pinto
+##
+##--------------------------------------------------------------------
+
+set -e
+
+PKG_NAME="foglamp-south-modbusc"
+
+get_foglamp_script () {
+    foglamp_script=$(dpkg -L foglamp | grep 'foglamp/bin/foglamp$')
+    echo $foglamp_script
+}
+
+is_foglamp_running () {
+    set +e
+    foglamp_script=$(get_foglamp_script)
+    foglamp_status_output=$($foglamp_script status 2>&1 | grep 'FogLAMP Uptime')
+    rc=$((!$?))
+    echo $rc
+    set -e
+}
+
+is_plugin_installed () {
+    set +e
+    current_files_all=$(dpkg -L ${PKG_NAME} | grep 'foglamp/plugins/south/ModbusC/lib*')
+    rc=$((!$?))
+    echo $rc
+    set -e
+}
+
+# main
+IS_PLUGIN_INSTALLED=$(is_plugin_installed)
+if [ "$IS_PLUGIN_INSTALLED" -eq "1" ]; then
+    echo "FogLAMP C++ plugin ${PKG_NAME} is already installed: this is an upgrade/downgrade."
+    # exit if foglamp is running
+    IS_FOGLAMP_RUNNING=$(is_foglamp_running)
+    if [ "$IS_FOGLAMP_RUNNING" -eq "1" ]
+    then
+        echo "*** ERROR. FogLAMP is currently running. Stop FogLAMP and try again. ***"
+        exit 1
+    fi
+fi

--- a/packages/Debian/x86_64/DEBIAN/control
+++ b/packages/Debian/x86_64/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: foglamp-south-modbusc
+Version: 1.0.0
+Section: devel
+Priority: optional
+Architecture: amd64
+Depends: foglamp
+Conflicts:
+Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
+Homepage: http://www.dianomic.com
+Description: FogLAMP C++ Modbus south plugin


### PR DESCRIPTION
FOGL-1804: modbus c Debian packaging

Note:

Package name doesn't  show "modubus-c",  "modbusc" is the new name

- repository name: "foglamp-south-modbus-c"
- package name: "foglamp-south-modbusc-1.0.0-x86_64.deb"
- plugin dir: "plugins/south/ModbuC"
- plugin shared object name: "libModbusC.so"